### PR TITLE
fix: 수정된 패킷 헤더 명세에 따라 코드 수정

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -16,11 +16,13 @@ import {
   REDIS_HOST,
   REDIS_NAME,
   REDIS_PASSWORD,
-  REDIS_PORT
+  REDIS_PORT,
 } from '../constants/env.js';
 import {
   PAYLOAD_LENGTH_SIZE,
   PAYLOAD_ONEOF_CASE_SIZE,
+  ROOM_ID_SIZE,
+  ROOMSTATE_SIZE,
   SEQUENCE_SIZE,
   VERSION_LENGTH_SIZE,
 } from '../constants/header.js';
@@ -34,6 +36,8 @@ export const config = {
     version: CLIENT_VERSION,
   },
   header: {
+    ROOMSTATE_SIZE,
+    ROOM_ID_SIZE,
     PAYLOAD_ONEOF_CASE_SIZE,
     VERSION_LENGTH_SIZE,
     SEQUENCE_SIZE,
@@ -63,5 +67,5 @@ export const config = {
     port: REDIS_PORT,
     name: REDIS_NAME,
     password: REDIS_PASSWORD,
-  }
+  },
 };

--- a/src/constants/header.js
+++ b/src/constants/header.js
@@ -1,3 +1,5 @@
+export const ROOMSTATE_SIZE = 1;
+export const ROOM_ID_SIZE = 4;
 export const PAYLOAD_ONEOF_CASE_SIZE = 2;
 export const VERSION_LENGTH_SIZE = 1;
 export const SEQUENCE_SIZE = 4;

--- a/src/constants/header.js
+++ b/src/constants/header.js
@@ -1,4 +1,4 @@
-export const ROOMSTATE_SIZE = 1;
+export const ROOMSTATE_SIZE = 2;
 export const ROOM_ID_SIZE = 4;
 export const PAYLOAD_ONEOF_CASE_SIZE = 2;
 export const VERSION_LENGTH_SIZE = 1;

--- a/src/events/onData.js
+++ b/src/events/onData.js
@@ -23,11 +23,12 @@ export const onData = (socket) => async (data) => {
     PAYLOAD_LENGTH_SIZE;
 
   while (socket.buffer.length >= headerSize) {
-    const roomState = socket.buffer.readUInt8(0);
+    // 2 byte로 읽어야함
+    const roomState = socket.buffer.readUInt16BE(0);
     console.log(`RoomState: ${roomState}`);
 
     const roomIdOffset = ROOMSTATE_SIZE;
-    // WARN: 사이즈 32B 아님
+    // 4 bytes
     const roomId = socket.buffer.readUInt32BE(roomIdOffset);
     console.log(`RoomId: ${roomId}`);
 
@@ -75,6 +76,7 @@ export const onData = (socket) => async (data) => {
 
     try {
       const decodedPacket = Packets.GamePacket.decode(payload);
+      console.log(`decoded payload: ${decodedPacket}`);
       const handler = getHandlerByPacketType(payloadOneofCase);
       if (handler) {
         const t0 = performance.now();

--- a/src/events/onData.js
+++ b/src/events/onData.js
@@ -4,6 +4,8 @@ import { getHandlerByPacketType } from '../handler/index.js';
 import { Packets } from '../init/loadProtos.js';
 import getPacketTypeName from '../utils/getPacketTypeName.js';
 
+const ROOMSTATE_SIZE = config.header.ROOMSTATE_SIZE;
+const ROOM_ID_SIZE = config.header.ROOM_ID_SIZE;
 const PAYLOAD_ONEOF_CASE_SIZE = config.header.PAYLOAD_ONEOF_CASE_SIZE;
 const VERSION_LENGTH_SIZE = config.header.VERSION_LENGTH_SIZE;
 const SEQUENCE_SIZE = config.header.SEQUENCE_SIZE;
@@ -13,11 +15,29 @@ export const onData = (socket) => async (data) => {
   socket.buffer = Buffer.concat([socket.buffer, data]);
 
   const headerSize =
-    PAYLOAD_ONEOF_CASE_SIZE + VERSION_LENGTH_SIZE + SEQUENCE_SIZE + PAYLOAD_LENGTH_SIZE;
+    ROOMSTATE_SIZE +
+    ROOM_ID_SIZE +
+    PAYLOAD_ONEOF_CASE_SIZE +
+    VERSION_LENGTH_SIZE +
+    SEQUENCE_SIZE +
+    PAYLOAD_LENGTH_SIZE;
 
   while (socket.buffer.length >= headerSize) {
-    const payloadOneofCase = socket.buffer.readUInt16BE(0);
-    const versionLength = socket.buffer.readUInt8(PAYLOAD_ONEOF_CASE_SIZE);
+    const roomState = socket.buffer.readUInt8(0);
+    console.log(`RoomState: ${roomState}`);
+
+    const roomIdOffset = ROOMSTATE_SIZE;
+    // WARN: 사이즈 32B 아님
+    const roomId = socket.buffer.readUInt32BE(roomIdOffset);
+    console.log(`RoomId: ${roomId}`);
+
+    const payloadOneofCaseOffset = roomIdOffset + ROOM_ID_SIZE;
+    const payloadOneofCase = socket.buffer.readUInt16BE(payloadOneofCaseOffset);
+    console.log(`packetType: ${getPacketTypeName(payloadOneofCase)}`);
+
+    const versionLengthOffset = payloadOneofCaseOffset + PAYLOAD_ONEOF_CASE_SIZE;
+    const versionLength = socket.buffer.readUInt8(versionLengthOffset);
+
     const totalHeaderLength = headerSize + versionLength;
 
     // 전체 패킷이 준비될 때까지 반복하기 위해 break
@@ -25,13 +45,15 @@ export const onData = (socket) => async (data) => {
       break;
     }
 
-    const versionOffset = PAYLOAD_ONEOF_CASE_SIZE + VERSION_LENGTH_SIZE;
+    const versionOffset = versionLengthOffset + VERSION_LENGTH_SIZE;
     const version = socket.buffer.toString('utf-8', versionOffset, versionOffset + versionLength);
+    console.log(`version: ${version}`);
 
     // TODO: 클라이언트 version 검증
 
     const sequenceOffset = versionOffset + versionLength;
     const sequence = socket.buffer.readUInt32BE(sequenceOffset);
+    console.log(`sequence: ${sequence}`);
 
     const payloadLengthOffset = sequenceOffset + SEQUENCE_SIZE;
     const payloadLength = socket.buffer.readUInt32BE(payloadLengthOffset);
@@ -44,9 +66,12 @@ export const onData = (socket) => async (data) => {
       break;
     }
 
+    // NOTE: 이 아래로 실행 안됨
+
     const payload = socket.buffer.slice(totalHeaderLength, packetLength);
     // 남은 데이터(payloadLength를 초과)가 있다면 다시 버퍼에 넣어줌
     socket.buffer = socket.buffer.slice(packetLength);
+    console.log(`payload: ${payload}`);
 
     try {
       const decodedPacket = Packets.GamePacket.decode(payload);

--- a/src/utils/response/createResponse.js
+++ b/src/utils/response/createResponse.js
@@ -2,6 +2,12 @@ import { config } from '../../config/config.js';
 import { Packets } from '../../init/loadProtos.js';
 
 const createHeader = (payloadOneofCase, sequence, payloadLength) => {
+  const roomState = Buffer.alloc(config.header.ROOMSTATE_SIZE);
+  roomState.writeUInt16BE(0, 0);
+
+  const roomId = Buffer.alloc(config.header.ROOM_ID_SIZE);
+  roomId.writeInt32BE(0, 0);
+
   const payloadOneofCaseBuffer = Buffer.alloc(config.header.PAYLOAD_ONEOF_CASE_SIZE);
   payloadOneofCaseBuffer.writeUInt16BE(payloadOneofCase, 0);
 
@@ -17,6 +23,8 @@ const createHeader = (payloadOneofCase, sequence, payloadLength) => {
   payloadLengthBuffer.writeUInt32BE(payloadLength, 0);
 
   return Buffer.concat([
+    roomState,
+    roomId,
     payloadOneofCaseBuffer,
     versionLengthBuffer,
     versionBuffer,


### PR DESCRIPTION
### 변경점
1. roomState, roomId 헤더의 크기를 header.js에 추가
2. 패킷을 읽는 onData, 패킷을 보내기 위한 함수 createHeader를 수정


> 클라이언트에서 enum은 2bytes로 처리하고 있었음.